### PR TITLE
Fix for status icon tooltip flickering

### DIFF
--- a/src/app/core/status/status.component.html
+++ b/src/app/core/status/status.component.html
@@ -9,6 +9,7 @@
 <span
   [tooltip]="networkTooltip"
   placement="left"
+  container="body"
   class="icon" >
     <img src="assets/icons/network/connect_{{getIconNumber()}}.png" />
 </span>
@@ -17,6 +18,7 @@
   class="icon"
   [tooltip]="encryptionTooltip"
   placement="left"
+  container="body"
   (click)="toggle()">
     <img src="assets/icons/lock/lock{{ getIconEncryption() }}.png" />
 </span>


### PR DESCRIPTION
This is fix for visual glitch when user moves pointer over status icon tooltip get shown and than start flickering and reposition itself.
Fixed by attaching tooltip to documents body instead of parent container.  