### PR TITLE
error message in syncing modal if RPC connected but no peers

### DIFF
--- a/src/app/core/rpc/blockstatus.service.ts
+++ b/src/app/core/rpc/blockstatus.service.ts
@@ -10,6 +10,7 @@ export class BlockStatusService {
 
   private _subBlockInternal: Subscription;
   private _subBlockNetwork: Subscription;
+  private _peers: Subscription;
 
   private highestBlockHeightNetwork: number = -1;
   private highestBlockHeightInternal: number = -1;
@@ -25,7 +26,8 @@ export class BlockStatusService {
     estimatedTimeLeft: undefined,
     manuallyOpened: false,
     networkBH: -1,
-    internalBH: -1
+    internalBH: -1,
+    peerList: undefined
   };
 
   constructor(
@@ -63,6 +65,13 @@ export class BlockStatusService {
           }
         },
         error => console.log('SyncingComponent subscription error:' + error));
+
+    /*
+    * Get list of peers to know if daemon is actually connected to peers
+    */
+    this._peers = this._peerService.getPeerList().subscribe(peerList => {
+      this.status.peerList = peerList;
+    });
   }
 
   /**

--- a/src/app/modals/syncing/syncing.component.html
+++ b/src/app/modals/syncing/syncing.component.html
@@ -8,6 +8,9 @@
         <div class="alert">
           <b>SPENDING PARTICL MAY NOT BE POSSIBLE DURING THAT PHASE!</b><!-- TODO: Red bold text (Information / Alert / Warning class?) -->
         </div>
+        <div *ngIf="nPeers < 1" class="alert">
+          Warning : no peers connected. Please check your Internet connection.
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/modals/syncing/syncing.component.ts
+++ b/src/app/modals/syncing/syncing.component.ts
@@ -18,12 +18,14 @@ export class SyncingComponent {
   estimatedTimeLeft: string;
   manuallyOpened: boolean;
   syncPercentage: number;
+  nPeers: number;
 
   constructor(
     private _blockStatusService: BlockStatusService,
     private _rpcService: RPCService
   ) {
     this._blockStatusService.statusUpdates.asObservable().subscribe(status => {
+      this.nPeers = status.peerList ? status.peerList.length : 0;
       this.remainder = status.remainingBlocks < 0
         ? 'waiting for peers...'
         : status.remainingBlocks;


### PR DESCRIPTION
PAR-151

Can't test this : if the daemon is already running when internet is disconnected, peersList still contains the peers that were connected before. If starting the daemon after internet is disconnected, RPC service doesn't emit updates.