### PR TITLE
fixed modals poping when manually closed

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -60,7 +60,7 @@ export class AppComponent implements OnInit {
 
   // TODO: remove Modal examples
   firsttime() {
-    this._modalsService.open('createWallet');
+    this._modalsService.open('createWallet', {forceOpen: true});
   }
 
   syncing() {

--- a/src/app/modals/modals.component.spec.ts
+++ b/src/app/modals/modals.component.spec.ts
@@ -46,7 +46,7 @@ describe('ModalsComponent', () => {
   });
 
   it('should open and close', () => {
-    component.open(UnlockwalletComponent);
+    component.open(UnlockwalletComponent, {forceOpen: true});
     expect(component.modal).toBeDefined();
     component.close();
   });

--- a/src/app/modals/modals.service.ts
+++ b/src/app/modals/modals.service.ts
@@ -68,7 +68,7 @@ export class ModalsService {
 
   close() {
     this.isOpen = false;
-    if (!this.manuallyClosed.includes(this.modal.name)) {
+    if (this.modal && !this.manuallyClosed.includes(this.modal.name)) {
       this.manuallyClosed.push(this.modal.name);
     }
   }

--- a/src/app/modals/modals.service.ts
+++ b/src/app/modals/modals.service.ts
@@ -20,6 +20,7 @@ export class ModalsService {
   public enableClose: boolean = true;
 
   private isOpen: boolean = false;
+  private manuallyClosed: any[] = [];
 
   private data: string;
 
@@ -51,10 +52,15 @@ export class ModalsService {
 
   open(modal: string, data?: any): void {
     if (modal in this.messages) {
-      this.log.d(`next modal: ${modal}`);
-      this.modal = this.messages[modal];
-      this.message.next({modal: this.modal, data: data});
-      this.isOpen = true;
+      if (
+        (data && data.forceOpen)
+        || !this.manuallyClosed.includes(this.messages[modal].name)
+      ) {
+        this.log.d(`next modal: ${modal}`);
+        this.modal = this.messages[modal];
+        this.message.next({modal: this.modal, data: data});
+        this.isOpen = true;
+      }
     } else {
       this.log.er(`modal ${modal} doesn't exist`);
     }
@@ -62,6 +68,9 @@ export class ModalsService {
 
   close() {
     this.isOpen = false;
+    if (!this.manuallyClosed.includes(this.modal.name)) {
+      this.manuallyClosed.push(this.modal.name);
+    }
   }
 
   getMessage() {


### PR DESCRIPTION
- added an array of `manuallyClosed` modal names (e.g. `SyncingComponent`) to the Modals service
- modal name is pushed to the array when the modal is first closed
- add `{forceOpen: true}` to force open a modal that may have been closed, e.g. when manually opening with a button press