### PR TITLE
RPC cookie

### DIFF
--- a/modules/clientBinaries/clientBinaries.js
+++ b/modules/clientBinaries/clientBinaries.js
@@ -4,9 +4,11 @@ const fs = require('fs');
 const { app, dialog } = require('electron');
 const got = require('got');
 const path = require('path');
-const ClientBinaryManager = require('./clientBinariesManager').Manager;
 const EventEmitter = require('events').EventEmitter;
 const spawn = require('child_process').spawn;
+
+const ClientBinaryManager = require('./clientBinariesManager').Manager;
+const auth = require('../rpc/rpcCookie').getCookie();
 
 const log = {
   info: console.log,
@@ -15,8 +17,8 @@ const log = {
   error: console.log
 };
 
-// should be       'https://raw.githubusercontent.com/ethereum/mist/master/clientBinaries.json'
-const BINARY_URL = 'https://raw.githubusercontent.com/pciavald/partgui/feature/daemonManager/modules/clientBinaries/clientBinaries.json';
+// should be 'https://raw.githubusercontent.com/particl/partgui/master/modules/clientBinaries/clientBinaries.json';
+const BINARY_URL = 'https://raw.githubusercontent.com/pciavald/partgui/master/modules/clientBinaries/clientBinaries.json';
 
 //const ALLOWED_DOWNLOAD_URLS_REGEX = new RegExp('*', 'i');
 
@@ -37,20 +39,48 @@ class Manager extends EventEmitter {
   }
 
   startDaemon() {
-    /**
-    const user = 'test';
-    const password = 'test';
-    */
-    const args = [
-      /*
-      `-rpcuser=${user}`,
-      `-rpcpassword=${password}`,
-      `-rpccorsdomain=http://localhost:4200`,
-      `-rpcport=51935`
-      */
-    ];
-    const child = spawn(this._availableClients['particld'].binPath, args);
-    return (child);
+    return new Promise((resolve, reject) => {
+
+      let args = [
+        `-testnet`,
+        `-reindex`,
+        `-rpccorsdomain=http://localhost:4200`,
+        `-rpcport=51935`,
+        `-rpcuser=${auth[0]}`,
+        `-rpcpassword=${auth[1]}`,
+        `getinfo`,
+      ];
+
+      // particl-cli path from the downloaded archive
+      let cliPath = path.join(
+        path.dirname(this._availableClients['particld'].binPath),
+        `particl-${this._availableClients['particld'].version}`,
+        'bin',
+        'particl-cli'
+      );
+
+      // particl-cli was not automatically downloaded and was already installed
+      if (!fs.existsSync(cliPath)) {
+        cliPath = 'particl-cli';
+      }
+
+      // spawn particl-cli getinfo to know if daemon is connected
+      const child = spawn(cliPath, args).on('close', (code) => {
+        if (code === 0) {
+          // daemon was already launched
+          console.info("daemon already launched");
+          resolve(undefined);
+        } else {
+          // daemon needs to be launched
+          console.info("launching daemon");
+          // remove particl-cli specific arguments: (user, pass, command getinfo)
+          args.length = 4;
+          const child = spawn(this._availableClients['particld'].binPath, args);
+          resolve(child);
+        }
+      })
+
+    });
   }
 
   getClient(clientId) {
@@ -153,51 +183,53 @@ class Manager extends EventEmitter {
 
           log.debug('New client binaries config found, asking user if they wish to update...');
 
-          // TODO start
-          const wnd = Windows.createPopup('clientUpdateAvailable', _.extend({
-            useWeb3: false,
-            electronOptions: {
-              width: 600,
-              height: 340,
-              alwaysOnTop: false,
-              resizable: false,
-              maximizable: false
-            }
-          }, {
-            sendData: {
-              uiAction_sendData: {
-                name: nodeType,
-                version: nodeVersion,
-                checksum: `${algorithm}: ${hash}`,
-                downloadUrl: binaryVersion.download.url,
-                restart
-              }
-            }
-          }), (update) => {
-            // update
-            if (update === 'update') {
-              this._writeLocalConfig(latestConfig);
+          log.debug('skipping ask user because Electron is not yet linked for that');
+          this._writeLocalConfig(latestConfig);
+          resolve(latestConfig);
 
-              resolve(latestConfig);
-
-              // skip
-            } else if (update === 'skip') {
-              fs.writeFileSync(
-                path.join(app.getPath('userData'), 'skippedNodeVersion.json'),
-                nodeVersion
-              );
-
-              resolve(localConfig);
-            }
-
-            wnd.close();
-          });
-
-          // if the window is closed, simply continue and as again next time
-          wnd.on('close', () => {
-            resolve(localConfig);
-          });
-          // TODO end
+          // const wnd = Windows.createPopup('clientUpdateAvailable', _.extend({
+          //   useWeb3: false,
+          //   electronOptions: {
+          //     width: 600,
+          //     height: 340,
+          //     alwaysOnTop: false,
+          //     resizable: false,
+          //     maximizable: false
+          //   }
+          // }, {
+          //   sendData: {
+          //     uiAction_sendData: {
+          //       name: nodeType,
+          //       version: nodeVersion,
+          //       checksum: `${algorithm}: ${hash}`,
+          //       downloadUrl: binaryVersion.download.url,
+          //       restart
+          //     }
+          //   }
+          // }), (update) => {
+          //   // update
+          //   if (update === 'update') {
+          //     this._writeLocalConfig(latestConfig);
+          //
+          //     resolve(latestConfig);
+          //
+          //     // skip
+          //   } else if (update === 'skip') {
+          //     fs.writeFileSync(
+          //       path.join(app.getPath('userData'), 'skippedNodeVersion.json'),
+          //       nodeVersion
+          //     );
+          //
+          //     resolve(localConfig);
+          //   }
+          //
+          //   wnd.close();
+          // });
+          //
+          // // if the window is closed, simply continue and as again next time
+          // wnd.on('close', () => {
+          //   resolve(localConfig);
+          // });
         });
       }
 

--- a/modules/clientBinaries/clientBinariesManager.js
+++ b/modules/clientBinaries/clientBinariesManager.js
@@ -17,6 +17,7 @@ const _ = {
 
 
 function copyFile(src, dst) {
+  console.log("COPYFILE", src, dst);
   return new Promise((resolve, reject) => {
     var rd = fs.createReadStream(src);
 
@@ -281,9 +282,9 @@ class Manager {
       if (algorithm) {
         return checksum(dInfo.downloadFile, algorithm)
           .then((hash) => {
-              this._logger.error(algorithm)
-                  this._logger.error(hash)
-                      this._logger.error(expectedHash)
+              this._logger.error(algorithm);
+              this._logger.error(hash);
+              this._logger.error(expectedHash);
             if (expectedHash !== hash) {
               throw new Error(`Hash mismatch: ${expectedHash}`);
             }
@@ -309,7 +310,6 @@ class Manager {
 
       if (options.unpackHandler) {
         this._logger.debug(`Invoking custom unpack handler ...`);
-
         promise = options.unpackHandler(downloadFile, unpackFolder);
       } else {
         switch (downloadCfg.type) {
@@ -348,7 +348,6 @@ class Manager {
         // need to rename binary?
         if (downloadCfg.bin) {
           let realPath = path.join(unpackFolder, downloadCfg.bin);
-
           try {
             fs.accessSync(linkPath, fs.R_OK);
             fs.unlinkSync(linkPath);
@@ -356,8 +355,7 @@ class Manager {
             if (e.code !== 'ENOENT')
               this._logger.warn(e);
           }
-
-          return copyFile(realPath, linkPath).then(() => linkPath)
+          return copyFile(realPath, linkPath).then(() => linkPath);
         } else {
           return Promise.resolve(linkPath);
         }

--- a/modules/rpc/rpcCookie.js
+++ b/modules/rpc/rpcCookie.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const rpc = require('node-bitcoin-rpc');
+const { ipcMain } = require('electron');
+const log = require('electron-log');
+const Observable = require('rxjs/Observable').Observable;
+const rxIpc = require('rx-ipc-electron/lib/main').default;
+
+const MAINNET_PORT = 51735;
+const TESTNET_PORT = 51935;
+
+const COOKIE_FILE = findCookiePath() + '/testnet/.cookie';
+
+function findCookiePath() {
+
+  var homeDir = os.homedir ? os.homedir() : process.env['HOME'];
+
+  var dir,
+      appName = 'Particl';
+  switch (process.platform) {
+    case 'linux': {
+      dir = prepareDir(homeDir, '.' + appName.toLowerCase())
+        .result;
+        console.log(dir)
+      break;
+    }
+
+    case 'darwin': {
+      dir = prepareDir(homeDir, 'Library', 'Application Support', appName)
+        .result;
+      break;
+    }
+
+    case 'win32': {
+      dir = prepareDir(process.env['APPDATA'], appName)
+        .or(homeDir, 'AppData', 'Roaming', appName)
+        .result;
+      break;
+    }
+  }
+
+  if (dir) {
+    return dir;
+  } else {
+    return false;
+  }
+}
+
+function prepareDir(dirPath) {
+  // jshint -W040
+  if (!this || this.or !== prepareDir || !this.result) {
+    if (!dirPath) {
+      return { or: prepareDir };
+    }
+
+    //noinspection JSCheckFunctionSignatures
+    dirPath = path.join.apply(path, arguments);
+    mkDir(dirPath);
+
+    try {
+      fs.accessSync(dirPath, fs.W_OK);
+    } catch (e) {
+      return { or: prepareDir };
+    }
+  }
+
+  return {
+    or: prepareDir,
+    result: (this ? this.result : false) || dirPath
+  };
+}
+
+function mkDir(dirPath, root) {
+  var dirs = dirPath.split(path.sep);
+  var dir = dirs.shift();
+  root = (root || '') + dir + path.sep;
+
+  try {
+    fs.mkdirSync(root);
+  } catch (e) {
+    if (!fs.statSync(root).isDirectory()) {
+      throw new Error(e);
+    }
+  }
+
+  return !dirs.length || mkDir(dirs.join(path.sep), root);
+}
+
+function getCookie() {
+  let auth = [];
+
+  if (fs.existsSync(COOKIE_FILE)) {
+    auth = fs.readFileSync(COOKIE_FILE, 'utf8').split(':');
+  } else {
+
+  }
+  console.log(COOKIE_FILE);
+  console.log(auth);
+  return (auth)
+  //else TODO: No cookie file...
+}
+
+exports.getCookie = getCookie;


### PR DESCRIPTION
### This pull request implements checking if a daemon is already running on the machine before launching the embedded daemon.
- created a new version of `modules/rpc/rpc.js` as `modules/rpc/rpcCookie.js` that does not subscribe to any IPC stuff, just returns cookie credentials.
   - [ ] Both files should be merged and reorganized as one module which exports 
        - a function that just returns the RPC credentials
        - function that connects IPC
- rewrote `startDaemon` function in `modules/clientBinaries/clientBinaries.js`

Still a work in progress as I've spotted a bug but didn't understand it yet. To reproduce :
```
npm run start:electron
ps aux | grep particld
```
Partgui launches but **RPC connection doesn't seem to work**.
Quit Partgui, launch `particld` the exact same way it was launched before (copy paste the output of `ps`), and run `npm run start:electron` again.
Now the embedded daemon is not being launched, because another daemon was detected by `particl-cli`'s `getinfo` command.
However, RPC connection seems to work this time, but **sync doesn't happen**.

### To sum up there are 2 remaining problems : 
- [ ] self-launching the daemon : RPC doesn't connect
- [ ] manually launched daemon : RPC connect but daemon doesn't sync