### PR TITLE
Disabling auto-update

### DIFF
--- a/modules/clientBinaries/clientBinaries.js
+++ b/modules/clientBinaries/clientBinaries.js
@@ -34,7 +34,7 @@ class Manager extends EventEmitter {
     log.info('Initializing...');
     options = _options;
     // check every hour
-    setInterval(() => this._checkForNewConfig(true), 1000 * 60 * 60);
+    // setInterval(() => this._checkForNewConfig(true), 1000 * 60 * 60);
     this._resolveBinPath();
     return this._checkForNewConfig(restart);
   }


### PR DESCRIPTION
This commit disables auto-updating every hour on the daemon, thus disabling the automatic restart of the wallet. Wallet core daemon will still update on launch.