### PR TITLE
Add missing flash notification on copy address

### DIFF
--- a/src/app/wallet/address-book/address-book.component.html
+++ b/src/app/wallet/address-book/address-book.component.html
@@ -5,7 +5,7 @@
       <div fxFlex="75" fxFlex.lt-md="60" fxFlex.lt-sm="100">
         <button md-button color="primary" (click)="openNewAddress()" class="add-address">
           <md-icon fontSet="partIcon" fontIcon="part-circle-add-2"></md-icon>
-          <span>Save Address</span>
+          <span>Add new address</span>
         </button>
       </div>
       <md-form-field class="icon-input search-address" fxFlex="25" fxFlex.lt-md="40" fxFlex.lt-sm="100">

--- a/src/app/wallet/receive/receive.component.html
+++ b/src/app/wallet/receive/receive.component.html
@@ -48,7 +48,7 @@
         </div>
 
         <div class="actions">
-          <button md-button class="copy" ngxClipboard [cbContent]="selected.address">
+          <button md-button class="copy" ngxClipboard [cbContent]="selected.address" (click)="copyToClipBoard()">
             <md-icon fontSet="partIcon" fontIcon="part-single-copy-04"></md-icon>
             Copy address
           </button>

--- a/src/app/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -9,7 +9,7 @@
         <qr-code [level]="'H'" size="150" value="particl:{{ singleAddress.address }}"></qr-code>
       </div>
     </div><!-- .qr-code -->
-    
+
     <div class="address-string">
       <div class="details-address enable-select" fxLayoutWrap layout-padding>
         <div *ngFor="let word of showAddress(singleAddress.address)" class="address-word" fxFlex="33">
@@ -18,12 +18,12 @@
       </div>
 
       <div class="actions">
-        <button md-button class="copy" ngxClipboard [cbContent]="singleAddress.address">
+        <button md-button class="copy" ngxClipboard [cbContent]="singleAddress.address" (click)="copyToClipBoard()">
           <md-icon fontSet="partIcon" fontIcon="part-single-copy-04"></md-icon>Copy to clipboard
         </button>
       </div>
     </div><!-- .address-string -->
-    
+
 
   </div>
   <md-dialog-actions fxLayoutAlign="center center">

--- a/src/app/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -1,4 +1,5 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
+import { FlashNotificationService } from '../../../services/flash-notification.service';
 
 @Component({
   selector: 'app-qr-code-modal',
@@ -15,12 +16,19 @@ export class QrCodeModalComponent {
 
   @ViewChild('qrCode') qrElementView: ElementRef;
 
+  constructor(private flashNotification: FlashNotificationService) {
+  }
+
   getQrSize() {
     return this.qrElementView.nativeElement.offsetWidth;
   }
 
   showAddress(address: string) {
     return address.match(/.{1,4}/g);
+  }
+
+  copyToClipBoard() {
+    this.flashNotification.open('Address copied to clipboard.', '');
   }
 
 }


### PR DESCRIPTION
#PRG “copy address” in receive address viewer copies the address but doesn’t show flash notification.
#PRG “copy address” doesn't show flash notification.
address book: change button "Save address" into "Add new address" #293 