### PR TITLE
removed unused sync modal part

### DIFF
--- a/src/app/modals/syncing/syncing.component.html
+++ b/src/app/modals/syncing/syncing.component.html
@@ -43,20 +43,3 @@
     </div><!-- .content -->
   </div><!-- .container -->
 </div><!-- if syncPercentage -->
-
-
-<div *ngIf="!syncPercentage">
-  <div class="container">
-    <div class="content">
-
-      <div class="section intro">
-        <img src="assets/loading.svg" id="loading">
-        <blockquote class="quote">
-          <p>To hide the signal you must generate noise.</p>
-          <footer class="author">Ido Kaiser</footer>
-        </blockquote>
-      </div><!-- .intro -->
-
-    </div><!-- .content -->
-  </div><!-- .container -->  
-</div><!-- if !syncPercentage -->


### PR DESCRIPTION
- fixes https://github.com/particl/partgui/issues/314
- removes unused `ngIf="!syncPercentage` part of the syncing modal, which was broken and never showed for more than a fraction of a second