### PR TITLE
bumping core to 0.15.1.0 for develop

### DIFF
--- a/modules/daemon/daemonManager.js
+++ b/modules/daemon/daemonManager.js
@@ -14,12 +14,12 @@ const rpc = require('../rpc/rpc');
 let options;
 
 // master
-// const BINARY_URL = 'https://raw.githubusercontent.com/particl/partgui/blob/develop/modules/clientBinaries/clientBinaries.json';
+// const BINARY_URL = 'https://raw.githubusercontent.com/particl/partgui/master/modules/clientBinaries/clientBinaries.json';
 
 // dev
-// const BINARY_URL = 'https://raw.githubusercontent.com/particl/partgui/blob/develop/modules/clientBinaries/clientBinaries.json';
+// const BINARY_URL = 'https://raw.githubusercontent.com/particl/partgui/develop/modules/clientBinaries/clientBinaries.json';
 
-const BINARY_URL = 'https://raw.githubusercontent.com/particl/partgui/blob/develop/modules/clientBinaries/clientBinaries.json';
+const BINARY_URL = 'https://raw.githubusercontent.com/particl/partgui/develop/modules/clientBinaries/clientBinaries.json';
 
 //const ALLOWED_DOWNLOAD_URLS_REGEX = new RegExp('*', 'i');
 


### PR DESCRIPTION
correcting #380 

I've made a mistake in the URLs in the previous PR. Sorry about that.