### PR TITLE
Sync modal

### DIFF
--- a/src/app/modals/shared/percentage-bar/percentage-bar.component.html
+++ b/src/app/modals/shared/percentage-bar/percentage-bar.component.html
@@ -15,7 +15,7 @@
 <div class="sync-progress-wrapper" *ngIf="initialized && sidebar && !(syncPercentage === 100)" mdTooltip="{{ syncString }}" matTooltipPosition="above">
 
   <p class="sync-info">
-    Syncing with the network
+    <md-spinner class="sync-spinner" color="accent"></md-spinner>Syncing with the network
   </p>
 
   <md-progress-bar

--- a/src/app/modals/shared/percentage-bar/percentage-bar.component.scss
+++ b/src/app/modals/shared/percentage-bar/percentage-bar.component.scss
@@ -24,4 +24,12 @@
     margin: 0 0 8px;
     color: $text-muted;
   }
+  .sync-spinner.mat-spinner {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    margin: 0 7px 0 0;
+    position: relative;
+    top: 3px;
+  }
 }

--- a/src/app/modals/syncing/syncing.component.html
+++ b/src/app/modals/syncing/syncing.component.html
@@ -22,7 +22,7 @@
           <span class="value">
             {{ remainder }}
             <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
-              <md-spinner class="sync-spinner"></md-spinner>
+                <md-spinner class="sync-spinner"></md-spinner>
             </div>
           </span>
 
@@ -31,18 +31,18 @@
       <div fxFlex="70" class="big item">
           <span class="value">
             {{ estimatedTimeLeft }}
-             <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
-               <md-spinner class="sync-spinner"></md-spinner>
-             </div>
+            <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
+                <md-spinner class="sync-spinner"></md-spinner>
+            </div>
           </span>
         <div class="description">Estimated time left</div>
       </div>
       <div fxFlex="100" class="small item">
           <span class="value">
             {{ lastBlockTime }}
-             <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
-               <md-spinner class="sync-spinner"></md-spinner>
-             </div>
+            <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
+                <md-spinner class="sync-spinner"></md-spinner>
+            </div>
           </span>
         <div class="description">Last Block time</div>
       </div>

--- a/src/app/modals/syncing/syncing.component.html
+++ b/src/app/modals/syncing/syncing.component.html
@@ -1,45 +1,48 @@
-<div *ngIf="syncPercentage">
-  <div class="container">
-    <div class="content">
+<div class="container">
+  <div class="content">
 
 
-      <div class="section wallet-syncing">
-        <div class="title">Wallet is syncing</div>
-        <p>
-          Your wallet automatically synchronizes with the Particl network after a connection is established, but this process has not completed yet. This means that recent transactions will not be visible, and the balance may not be up-to-date until this process has completed.
-        </p>
-        <p>
-          Spending Particl may not be possible during this phase
-        </p>
-        <p *ngIf="nPeers < 1" class="warning">
-          <md-icon fontSet="partIcon" fontIcon="part-alert"></md-icon>
-          Warning: No peers connected. Please check your internet connection
-        </p>
-      </div><!-- .wallet-syncing -->  
+    <div class="section wallet-syncing">
+      <div class="title">Wallet is syncing</div>
+      <p>
+        Your wallet automatically synchronizes with the Particl network after a connection is established, but this
+        process has not completed yet. This means that recent transactions will not be visible, and the balance may not
+        be up-to-date until this process has completed.
+      </p>
+      <p>
+        Spending Particl may not be possible during this phase
+      </p>
+      <p *ngIf="nPeers < 1" class="warning">
+        <md-icon fontSet="partIcon" fontIcon="part-alert"></md-icon>
+        Warning: No peers connected. Please check your internet connection
+      </p>
+    </div><!-- .wallet-syncing -->
 
-
-      <div class="section sync-stats" fxLayout="row" fxLayoutWrap>
-        <div fxFlex="30" class="big item">
+    <!-- @TODO: resize and align spinner  -->
+    <div class="section sync-stats" fxLayout="row" fxLayoutWrap>
+      <div fxFlex="30" class="big item">
           <span class="value">
-            {{ syncPercentage ? remainder : 'loading...' }}
+            {{ remainder }}
+            <md-spinner *ngIf="!syncPercentage"></md-spinner>
           </span>
-          <div class="description">Blocks to sync</div>
-        </div>
-        <div fxFlex="70" class="big item">
-          <span class="value">
-            {{ syncPercentage ? estimatedTimeLeft : 'loading...' }}
-          </span>
-          <div class="description">Estimated time left</div>
-        </div>
-        <div fxFlex="100" class="small item">
-          <span class="value">
-            {{ syncPercentage ? lastBlockTime : 'loading...' }}
-          </span>
-          <div class="description">Last Block time</div>
-        </div>
-      </div><!-- .sync-stats -->
 
-      
-    </div><!-- .content -->
-  </div><!-- .container -->
-</div><!-- if syncPercentage -->
+        <div class="description">Blocks to sync</div>
+      </div>
+      <div fxFlex="70" class="big item">
+          <span class="value">
+            {{ estimatedTimeLeft }}
+            <md-spinner *ngIf="!syncPercentage"></md-spinner>
+          </span>
+        <div class="description">Estimated time left</div>
+      </div>
+      <div fxFlex="100" class="small item">
+          <span class="value">
+            {{ lastBlockTime }}
+            <md-spinner *ngIf="!syncPercentage"></md-spinner>
+          </span>
+        <div class="description">Last Block time</div>
+      </div>
+    </div><!-- .sync-stats -->
+
+  </div><!-- .content -->
+</div><!-- .container -->

--- a/src/app/modals/syncing/syncing.component.html
+++ b/src/app/modals/syncing/syncing.component.html
@@ -1,7 +1,5 @@
 <div class="container">
   <div class="content">
-
-
     <div class="section wallet-syncing">
       <div class="title">Wallet is syncing</div>
       <p>
@@ -23,7 +21,9 @@
       <div fxFlex="30" class="big item">
           <span class="value">
             {{ remainder }}
-            <md-spinner *ngIf="!syncPercentage"></md-spinner>
+            <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
+              <md-spinner class="sync-spinner"></md-spinner>
+            </div>
           </span>
 
         <div class="description">Blocks to sync</div>
@@ -31,18 +31,21 @@
       <div fxFlex="70" class="big item">
           <span class="value">
             {{ estimatedTimeLeft }}
-            <md-spinner *ngIf="!syncPercentage"></md-spinner>
+             <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
+               <md-spinner class="sync-spinner"></md-spinner>
+             </div>
           </span>
         <div class="description">Estimated time left</div>
       </div>
       <div fxFlex="100" class="small item">
           <span class="value">
             {{ lastBlockTime }}
-            <md-spinner *ngIf="!syncPercentage"></md-spinner>
+             <div fxLayoutAlign="center center" *ngIf="!syncPercentage">
+               <md-spinner class="sync-spinner"></md-spinner>
+             </div>
           </span>
         <div class="description">Last Block time</div>
       </div>
     </div><!-- .sync-stats -->
-
   </div><!-- .content -->
 </div><!-- .container -->

--- a/src/assets/theme.scss
+++ b/src/assets/theme.scss
@@ -251,7 +251,7 @@ input[type="text"] {
 /**
  * Scrollbars
  */
- 
+
 /* pseudo elements
 ::-webkit-scrollbar              {}
 ::-webkit-scrollbar-button       {}
@@ -261,7 +261,7 @@ input[type="text"] {
 ::-webkit-scrollbar-corner       {}
 ::-webkit-resizer                {}
 */
- 
+
 ::-webkit-scrollbar-track {
   border-radius: 15px;
   background-color: #e9e9e9;
@@ -411,7 +411,7 @@ panel-header-title {
 
 /* ------------------------------- *\
     Pagination
-\* ------------------------------- */ 
+\* ------------------------------- */
 
 .mat-paginator {
   margin-top: 40px;
@@ -443,6 +443,10 @@ panel-header-title {
 .syncing_header_text{
   width: 65%;
   text-align: center;
+}
+
+.sync-spinner{
+  max-height: 30px;
 }
 
 .text-center {


### PR DESCRIPTION
When launched and blockchain isn't synced, the syncing modal (see #356) still fires up, even though it's empty.

We need not to launch the modal at all, syncing process is shown in the sidebar menu now.

(develop branch)
issue: https://github.com/particl/partgui/issues/381