### PR TITLE
Create wallet modal (GFX fix)

### DIFF
--- a/src/app/modals/encryptwallet/encryptwallet.component.html
+++ b/src/app/modals/encryptwallet/encryptwallet.component.html
@@ -7,19 +7,21 @@
         Please enter a password to encrypt your wallet.
       </p>
       <p class="warning">
-        <mat-icon fontSet="partIcon" fontIcon="part-alert"></mat-icon> Do NOT forget this password or you will be unable to access your coins
+        <mat-icon fontSet="partIcon" fontIcon="part-alert"></mat-icon>
+        Do NOT forget this password or you will be unable to access your coins
       </p>
     </div><!-- !password -->
 
 
     <!-- @TODO: Do we really need a confirmation for the password with "show password" option? -->
     <div *ngIf="password" class="section enter-password">
-      <div class="title">Choose a password</div>
+      <div class="title">Confirm your password</div>
       <p>
         Please enter your chosen password again to confirm it.
       </p>
       <p class="warning">
-        <mat-icon fontSet="partIcon" fontIcon="part-alert"></mat-icon> Do NOT forget this password or you will be unable to access your coins
+        <mat-icon fontSet="partIcon" fontIcon="part-alert"></mat-icon>
+        Do NOT forget this password or you will be unable to access your coins
       </p>
     </div><!-- !password -->
 
@@ -34,7 +36,10 @@
     </app-password>
     
     <div *ngIf="password" class="section go-back">
-      <button mat-button (click)="clearPassword()">Back</button>
+      <button mat-button (click)="clearPassword()">
+        <mat-icon fontSet="partIcon" fontIcon="part-previous-single"></mat-icon>
+        Back
+      </button>
     </div>
 
   </div><!-- .content -->

--- a/src/app/modals/modals.component.html
+++ b/src/app/modals/modals.component.html
@@ -1,4 +1,4 @@
-<button mat-raised-button class="close_button pull-right" (click)="close()" *ngIf="enableClose">
+<button class="close_button pull-right" (click)="close()" *ngIf="enableClose">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 

--- a/src/app/modals/shared/password/password.component.scss
+++ b/src/app/modals/shared/password/password.component.scss
@@ -17,4 +17,7 @@ input[type=checkbox] + label {
 
 .actions { // area with button(s)
   margin: 10px 0 20px;
+  button {
+    margin: 0;
+  }
 }

--- a/src/app/modals/shared/password/password.component.ts
+++ b/src/app/modals/shared/password/password.component.ts
@@ -20,7 +20,7 @@ export class PasswordComponent {
   stakeOnly: boolean = false;
   showPass: boolean = false;
 
-  @Input() label: string = 'YOUR WALLET PASSWORD';
+  @Input() label: string = 'Your wallet password';
   @Input() buttonText: string;
   @Input() unlockTimeout: number = 60;
   @Input() showStakeOnly: boolean = true;

--- a/src/assets/theme.scss
+++ b/src/assets/theme.scss
@@ -29,7 +29,8 @@
 
 // ------ BUTTONS ------ //
 
-.mat-button {
+.mat-button,
+button {
   .mat-icon {
     width: auto;
     height: auto;
@@ -358,6 +359,8 @@ input {
       background: transparent;
       color: $text-muted;
       min-width: 50px;
+      outline: none;
+      cursor: pointer;
       .mat-icon {
         color: rgba($color-alert, 0.5);
         border-radius: 50%;


### PR DESCRIPTION
Closes https://github.com/particl/partgui/issues/546

- fixes misplaced icons (for some reason the buttons there don't have `.mat-button` class, so they weren't getting the styles)
- fixed focused modal's close button on open (that's why the grey background was there)