### PR TITLE
updating wallet checking logic

### DIFF
--- a/src/app/core/rpc/rpc-state/rpc-state.class.ts
+++ b/src/app/core/rpc/rpc-state/rpc-state.class.ts
@@ -85,12 +85,12 @@ export class RpcStateClass {
         return;
       }
 
-      this._rpc.call('extkey', ['list']).subscribe(response => {
+      this._rpc.call('getwalletinfo').subscribe(response => {
         // check if account is active
-        if (response.result === 'No keys to list.') {
-          this._rpc.state.set('ui:walletInitialized', false);
-        } else {
+        if (!!response.hdmasterkey) {
           this._rpc.state.set('ui:walletInitialized', true);
+        } else {
+          this._rpc.state.set('ui:walletInitialized', false);
         }
       }, error => this.log.er('RPC Call returned an error', error));
     });


### PR DESCRIPTION
wallet checking was broken as it checked for wallet creation by sending the `extkey list` RPC command which has non deterministic result (if gui crashed during wallet creation for instance)

Replacing by correct logic using `walletsettings` and checking if `hdmasterkey` is set.