### PR TITLE
Status icons (retina) fix

### DIFF
--- a/src/app/core-ui/main/status/status.component.html
+++ b/src/app/core-ui/main/status/status.component.html
@@ -1,7 +1,7 @@
 <div class="status-icon disable-select">
 
   <span class="status icon" matTooltip="Peers: {{ peerListCount }}">
-    <img src="assets/icons/network/connect_{{ getIconNumber() }}.png"/>
+    <img src="assets/icons/SVG/network/peers-{{ getIconNumber() }}.svg"/>
   </span>
 
   <span
@@ -9,7 +9,7 @@
     matTooltip="{{ encryptionStatus }}"
     container="body"
     (click)="toggle()">
-      <img src="assets/icons/lock/lock{{ getIconEncryption() }}.png"/>
+      <img src="assets/icons/SVG/lock/lock{{ getIconEncryption() }}.svg"/>
   </span>
 
   <span

--- a/src/app/core-ui/main/status/status.component.ts
+++ b/src/app/core-ui/main/status/status.component.ts
@@ -59,13 +59,13 @@ export class StatusComponent implements OnInit {
     switch (this.encryptionStatus) {
       case 'Unencrypted':  // TODO: icon?
       case 'Unlocked':
-        return '_off';
+        return '-off';
       case 'Unlocked, staking only':
-        return '_stake';
+        return '-stake';
       case 'Locked':
         return '';
       default:
-        return '_off'; // TODO: icon?
+        return '-off'; // TODO: icon?
     }
   }
 

--- a/src/assets/icons/SVG/lock/lock-off.svg
+++ b/src/assets/icons/SVG/lock/lock-off.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="517 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg249"
+   sodipodi:docname="lock-off.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata255">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs253" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1174"
+     id="namedview251"
+     showgrid="false"
+     inkscape:zoom="2.0669275"
+     inkscape:cx="112.94294"
+     inkscape:cy="-22.255986"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg249" />
+  <path
+     d=" M 523 434 C 523 434.6 523.4 435 524 435 L 536 435 C 536.6 435 537 434.6 537 434 L 537 425 C 537 424.4 536.6 424 536 424 L 528 424 L 528 423 C 528 421.9 528.9 421 530 421 C 530.6 421 531.1 421.2 531.5 421.7 L 532.2 422.4 L 533.7 421.1 L 533 420.3 C 532.2 419.5 531.1 419 530 419 C 527.8 419 526 420.8 526 423 L 526 424 L 524 424 C 523.4 424 523 424.4 523 425 L 523 434 Z  M 530 427 C 531.1 427 532 427.9 532 429 C 532 429.7 531.6 430.4 531 430.7 L 531 432 L 529 432 L 529 430.7 C 528.4 430.4 528 429.7 528 429 C 528 427.9 528.9 427 530 427 Z "
+     fill="rgb(2,232,176)"
+     id="path165" />
+</svg>

--- a/src/assets/icons/SVG/lock/lock-stake.svg
+++ b/src/assets/icons/SVG/lock/lock-stake.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="547 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg249"
+   sodipodi:docname="lock-stake.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata255">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs253" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1174"
+     id="namedview251"
+     showgrid="false"
+     inkscape:zoom="2.0669275"
+     inkscape:cx="76.221003"
+     inkscape:cy="-109.25113"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg249" />
+  <path
+     d=" M 560 419 C 557.8 419 556 420.8 556 423 L 556 424 L 554 424 C 553.4 424 553 424.4 553 425 L 553 434 C 553 434.6 553.4 435 554 435 L 566 435 C 566.6 435 567 434.6 567 434 L 567 425 C 567 424.4 566.6 424 566 424 L 564 424 L 564 423 C 564 420.8 562.2 419 560 419 Z  M 561 430.7 L 561 432 L 559 432 L 559 430.7 C 558.4 430.4 558 429.7 558 429 C 558 427.9 558.9 427 560 427 C 561.1 427 562 427.9 562 429 C 562 429.7 561.6 430.4 561 430.7 Z  M 562 424 L 558 424 L 558 423 C 558 421.9 558.9 421 560 421 C 561.1 421 562 421.9 562 423 L 562 424 Z "
+     fill="rgb(243,147,71)"
+     id="path167" />
+</svg>

--- a/src/assets/icons/SVG/lock/lock.svg
+++ b/src/assets/icons/SVG/lock/lock.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="487 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg249"
+   sodipodi:docname="lock.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata255">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs253" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1174"
+     id="namedview251"
+     showgrid="false"
+     inkscape:zoom="1.4615385"
+     inkscape:cx="147.26378"
+     inkscape:cy="-68.751677"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg249" />
+  <path
+     d=" M 500 419 C 497.8 419 496 420.8 496 423 L 496 424 L 494 424 C 493.4 424 493 424.4 493 425 L 493 434 C 493 434.6 493.4 435 494 435 L 506 435 C 506.6 435 507 434.6 507 434 L 507 425 C 507 424.4 506.6 424 506 424 L 504 424 L 504 423 C 504 420.8 502.2 419 500 419 Z  M 501 430.7 L 501 432 L 499 432 L 499 430.7 C 498.4 430.4 498 429.7 498 429 C 498 427.9 498.9 427 500 427 C 501.1 427 502 427.9 502 429 C 502 429.7 501.6 430.4 501 430.7 Z  M 502 424 L 498 424 L 498 423 C 498 421.9 498.9 421 500 421 C 501.1 421 502 421.9 502 423 L 502 424 Z "
+     fill="rgb(227,34,60)"
+     id="path163" />
+</svg>

--- a/src/assets/icons/SVG/network/peers-0.svg
+++ b/src/assets/icons/SVG/network/peers-0.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="616 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg249"
+   sodipodi:docname="peers-0.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata255">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs253" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview251"
+     showgrid="false"
+     inkscape:zoom="2.0669275"
+     inkscape:cx="192.28759"
+     inkscape:cy="-72.076608"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg249" />
+  <path
+     d=" M 629 419 C 624.6 419 621 422.6 621 427 C 621 431.4 624.6 435 629 435 C 633.4 435 637 431.4 637 427 C 637 422.6 633.4 419 629 419 Z  M 629 421 C 630.3 421 631.5 421.4 632.5 422.1 L 624.1 430.5 C 623.4 429.5 623 428.3 623 427 C 623 423.7 625.7 421 629 421 Z  M 629 433 C 627.7 433 626.5 432.6 625.5 431.9 L 633.9 423.5 C 634.6 424.5 635 425.7 635 427 C 635 430.3 632.3 433 629 433 Z "
+     fill="rgb(227,34,60)"
+     id="path169" />
+</svg>

--- a/src/assets/icons/SVG/network/peers-1.svg
+++ b/src/assets/icons/SVG/network/peers-1.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="646 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg504"
+   sodipodi:docname="peers-1.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata510">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs508" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview506"
+     showgrid="false"
+     inkscape:zoom="1.4615385"
+     inkscape:cx="263.3185"
+     inkscape:cy="-170.46873"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg504" />
+  <g
+     id="peers_1">
+    <rect
+       x="648"
+       y="432"
+       width="2"
+       height="3"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect426" />
+    <rect
+       x="652"
+       y="430"
+       width="2"
+       height="5"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect428" />
+    <rect
+       x="656"
+       y="428"
+       width="2"
+       height="7"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect430" />
+    <rect
+       x="660"
+       y="426"
+       width="2"
+       height="9"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect432" />
+    <rect
+       x="664"
+       y="424"
+       width="2"
+       height="11"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect434" />
+    <rect
+       x="668"
+       y="422"
+       width="2"
+       height="13"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect436" />
+  </g>
+</svg>

--- a/src/assets/icons/SVG/network/peers-2.svg
+++ b/src/assets/icons/SVG/network/peers-2.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="686 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg759"
+   sodipodi:docname="peers-2.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs763" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview761"
+     showgrid="false"
+     inkscape:zoom="2.0669275"
+     inkscape:cx="187.89475"
+     inkscape:cy="-117.84721"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg759" />
+  <g
+     id="peers_2">
+    <rect
+       x="688"
+       y="432"
+       width="2"
+       height="3"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect694" />
+    <rect
+       x="692"
+       y="430"
+       width="2"
+       height="5"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect696" />
+    <rect
+       x="696"
+       y="428"
+       width="2"
+       height="7"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect698" />
+    <rect
+       x="700"
+       y="426"
+       width="2"
+       height="9"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect700" />
+    <rect
+       x="704"
+       y="424"
+       width="2"
+       height="11"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect702" />
+    <rect
+       x="708"
+       y="422"
+       width="2"
+       height="13"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect704" />
+  </g>
+</svg>

--- a/src/assets/icons/SVG/network/peers-3.svg
+++ b/src/assets/icons/SVG/network/peers-3.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="726 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg1014"
+   sodipodi:docname="peers-3.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata1020">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1018" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview1016"
+     showgrid="false"
+     inkscape:zoom="2.0669275"
+     inkscape:cx="182.22656"
+     inkscape:cy="-52.096253"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1014" />
+  <g
+     id="peers_3">
+    <rect
+       x="728"
+       y="432"
+       width="2"
+       height="3"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect962" />
+    <rect
+       x="732"
+       y="430"
+       width="2"
+       height="5"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect964" />
+    <rect
+       x="736"
+       y="428"
+       width="2"
+       height="7"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect966" />
+    <rect
+       x="740"
+       y="426"
+       width="2"
+       height="9"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect968" />
+    <rect
+       x="744"
+       y="424"
+       width="2"
+       height="11"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect970" />
+    <rect
+       x="748"
+       y="422"
+       width="2"
+       height="13"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect972" />
+  </g>
+</svg>

--- a/src/assets/icons/SVG/network/peers-4.svg
+++ b/src/assets/icons/SVG/network/peers-4.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="766 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg1269"
+   sodipodi:docname="peers-4.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata1275">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1273" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview1271"
+     showgrid="false"
+     inkscape:zoom="1.4615385"
+     inkscape:cx="163.31858"
+     inkscape:cy="-63.395804"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1269" />
+  <g
+     id="peers_4">
+    <rect
+       x="768"
+       y="432"
+       width="2"
+       height="3"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1230" />
+    <rect
+       x="772"
+       y="430"
+       width="2"
+       height="5"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1232" />
+    <rect
+       x="776"
+       y="428"
+       width="2"
+       height="7"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1234" />
+    <rect
+       x="780"
+       y="426"
+       width="2"
+       height="9"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1236" />
+    <rect
+       x="784"
+       y="424"
+       width="2"
+       height="11"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect1238" />
+    <rect
+       x="788"
+       y="422"
+       width="2"
+       height="13"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect1240" />
+  </g>
+</svg>

--- a/src/assets/icons/SVG/network/peers-5.svg
+++ b/src/assets/icons/SVG/network/peers-5.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="806 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg1524"
+   sodipodi:docname="peers-5.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata1530">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1528" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview1526"
+     showgrid="false"
+     inkscape:zoom="1.4615385"
+     inkscape:cx="254.90167"
+     inkscape:cy="-62.051992"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1524" />
+  <g
+     id="peers_5">
+    <rect
+       x="808"
+       y="432"
+       width="2"
+       height="3"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1498" />
+    <rect
+       x="812"
+       y="430"
+       width="2"
+       height="5"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1500" />
+    <rect
+       x="816"
+       y="428"
+       width="2"
+       height="7"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1502" />
+    <rect
+       x="820"
+       y="426"
+       width="2"
+       height="9"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1504" />
+    <rect
+       x="824"
+       y="424"
+       width="2"
+       height="11"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1506" />
+    <rect
+       x="828"
+       y="422"
+       width="2"
+       height="13"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(22,21,27)"
+       id="rect1508" />
+  </g>
+</svg>

--- a/src/assets/icons/SVG/network/peers-6.svg
+++ b/src/assets/icons/SVG/network/peers-6.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="isolation:isolate"
+   viewBox="846 419 26 16"
+   width="26"
+   height="16"
+   version="1.1"
+   id="svg1779"
+   sodipodi:docname="peers-6.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata1785">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1783" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1326"
+     id="namedview1781"
+     showgrid="false"
+     inkscape:zoom="2.9230769"
+     inkscape:cx="-95.16813"
+     inkscape:cy="-10.66397"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1779" />
+  <g
+     id="peers_6">
+    <rect
+       x="848"
+       y="432"
+       width="2"
+       height="3"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1766" />
+    <rect
+       x="852"
+       y="430"
+       width="2"
+       height="5"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1768" />
+    <rect
+       x="856"
+       y="428"
+       width="2"
+       height="7"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1770" />
+    <rect
+       x="860"
+       y="426"
+       width="2"
+       height="9"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1772" />
+    <rect
+       x="864"
+       y="424"
+       width="2"
+       height="11"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1774" />
+    <rect
+       x="868"
+       y="422"
+       width="2"
+       height="13"
+       transform="matrix(1,0,0,1,0,0)"
+       fill="rgb(3,232,176)"
+       id="rect1776" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #680 

![screenshot from 2018-01-17 16-43-52](https://user-images.githubusercontent.com/1965795/35051509-aef6dfae-fba5-11e7-916c-06fded904fd0.png)

- switched status icons to SVG
- took the opportunity to switch color of locked and unlocked wallet (IMO red as locked and green as unlocked is perceived more logically) – I can ofc switch that back if you don't share my views